### PR TITLE
Minor regular-expressions.Rmd modification

### DIFF
--- a/vignettes/regular-expressions.Rmd
+++ b/vignettes/regular-expressions.Rmd
@@ -206,7 +206,7 @@ You can also create your own __character classes__ using `[]`:
 * `[a-z]`: matches every character between a and z 
    (in Unicode code point order).
 * `[^abc]`: matches anything except a, b, or c.
-* `[\^\-]`: matches `-` or `\`.
+* `[\^\-]`: matches `-` or `^`.
 
 There are a number of pre-built classes that you can use inside `[]`:
 


### PR DESCRIPTION
From this line:
[* `[\^\-]`: matches `-` or `\`](https://github.com/tidyverse/stringr/blame/master/vignettes/regular-expressions.Rmd#L209)
I think it was meant to say:
[* `[\^\-]`: matches `-` or `^`]()
Older versions of the line:
[Use `\-` or `\^` to match those characters.](https://github.com/tidyverse/stringr/blame/79ae1e011ea0fcb6f5c3350a50f6a6da0dcaf09e/vignettes/regular-expressions.Rmd#L174)